### PR TITLE
Add identify device feature to keithley 2410 and 2510

### DIFF
--- a/src/odin_gpib/gpibdevice.py
+++ b/src/odin_gpib/gpibdevice.py
@@ -11,10 +11,35 @@ class GpibDevice():
         self.device = device
         self.bus_address = self.device.primary_address
         self.ident = ident.strip()
+        self.type = ""
 
         self.last_error = "No recorded errors"
         self.error_count = 0
-    
+
+        self.identify = False
+
+    def set_identify(self, identify):
+        # If identify toggle is turned on,
+        # display the identify message on the device screen.
+        # To do this, message state needs to be turned on.
+        # Max character length for top display message = 12 characters.
+        # Max character length for bottom display message = 32 characters.
+        # device_name is formed consisting of the machine's type and bus_address,
+        # it will be in the format K1234_56
+
+        if (identify == True):
+            device_name = "{:s}_{:d}".format(self.type, self.bus_address)
+            self.write(':DISP:WINDOW1:TEXT:DATA "Identify"')
+            self.write(':DISP:WINDOW1:TEXT:STAT 1')
+            self.write(':DISP:WINDOW2:TEXT:DATA "' + device_name + '"')
+            self.write(':DISP:WINDOW2:TEXT:STAT 1')
+        # Else, disable the message state to remove the message
+        else:
+            self.write(':DISP:WINDOW1:TEXT:STAT 0')
+            self.write(':DISP:WINDOW2:TEXT:STAT 0')
+
+        self.identify = identify
+
     def __repr__(self):
         #when devices is printed it will show the idnt and at the address
         return f'{self.ident}, at addr {self.device.primary_address}'
@@ -36,7 +61,7 @@ class GpibDevice():
             with self.lock:
                 self.device.write(cmd)
                 #ret = self.device.write(cmd)
-                #return ret 
+                #return ret
 
     def query(self, cmd):
         if self.device_control_enable:
@@ -54,7 +79,7 @@ class GpibDevice():
     def query_ascii_values(self, cmd):
         print(self.bus_address,": Last Error: ",self.last_error," | No of Errors: ",self.error_count)
         if self.device_control_enable:
-            try:           
+            try:
                 with self.lock:
                     ret = self.device.query_ascii_values(cmd)
                     return ret
@@ -66,8 +91,8 @@ class GpibDevice():
             except:
                 self.error_count += 1
                 self.last_error = "Something went wrong"
-                return None       
+                return None
 
-    
+
     def ret_control_state(self):
         return self.device_control_enable

--- a/src/odin_gpib/keithley2410.py
+++ b/src/odin_gpib/keithley2410.py
@@ -27,12 +27,11 @@ class K2410(GpibDevice):
             self.output_state = True
         if ("0" in output_init_state):
             self.output_state = False
-        
+
         print("OUTPUT: ",self.output_state)
 
         self.device_control_enable = True
         self.ramping_flag = False
-        self.identify = False
         self.write(':DISP:WINDOW1:TEXT:STAT 0')
         self.write(':DISP:WINDOW2:TEXT:STAT 0')
 
@@ -53,13 +52,13 @@ class K2410(GpibDevice):
         self.current_comp_setpoint = 0.0
         self.current_meas = 0.0
         self.current_curr_comp = 0.0
-        
+
         filter_controls = ParameterTree({
             'filter_enable' : (lambda: self.filter_set_enable, self.set_filter_enable),
             'filter_type' : (lambda: self.filter_set_type, self.set_filter_type),
             'filter_count' : (lambda: self.filter_count_setpoint, self.set_filter_count),
             'filter_curr_type' : (lambda: self.filter_curr_type, None),
-            'filter_curr_count' : (lambda: self.filter_curr_count, None),            
+            'filter_curr_count' : (lambda: self.filter_curr_count, None),
             'filter_state' : (lambda: self.filter_curr_state, None)
         })
 
@@ -93,7 +92,7 @@ class K2410(GpibDevice):
 
     def set_time(self, time):
         self.voltage_time = time
-    
+
     def set_ramping_flag(self,flag):
         self.ramping_flag = flag
 
@@ -106,7 +105,7 @@ class K2410(GpibDevice):
                 self.output_state = True
             if ("0" in output_state):
                 self.output_state = False
-    
+
     def set_output_state(self, output_state):
         if output_state == False:
             output_state = "OFF"
@@ -122,23 +121,6 @@ class K2410(GpibDevice):
         if (self.device_control_enable == False):
             self.write(':SYSTEM:KEY 23')
 
-    def set_identify(self, identify):
-        self.identify = identify
-        #ident = self.ident
-        # If identify toggle turned on, display the identify message on the screen.
-        # To do this, message state needs to be turned on.
-        # Max character length for top display message = 12 characters
-        # Max character length for bottom display message = 32 characters
-        if (self.identify == True):
-            self.write(':DISP:WINDOW1:TEXT:DATA "Identify"')
-            self.write(':DISP:WINDOW1:TEXT:STAT 1')
-            self.write(':DISP:WINDOW2:TEXT:DATA "Bottom Text - Yay"')
-            self.write(':DISP:WINDOW2:TEXT:STAT 1')
-        # Else, disable the message state to remove the message
-        else:
-            self.write(':DISP:WINDOW1:TEXT:STAT 0')
-            self.write(':DISP:WINDOW2:TEXT:STAT 0')
-                                               
     def get_voltage_measurement(self):
         voltage_meas = (self.query_ascii_values(':MEAS:VOLT?'))
         if (voltage_meas == None):
@@ -152,7 +134,7 @@ class K2410(GpibDevice):
             pass
         else:
             self.voltage_curr_range = voltage_curr_range
-        
+
     def get_filter_state(self):
         filter_curr_state = (self.query(':SENS:AVER:STAT?'))
         if (filter_curr_state == None):
@@ -170,7 +152,7 @@ class K2410(GpibDevice):
         if (filter_curr_count == None):
             pass
         else:
-            self.filter_curr_count = filter_curr_count        
+            self.filter_curr_count = filter_curr_count
 
     def get_filter_curr_type(self):
         filter_curr_type = (self.query(':SENS:AVER:TCON?'))
@@ -183,7 +165,7 @@ class K2410(GpibDevice):
             elif "REP" in self.filter_curr_type:
                 self.filter_curr_type = "Repeating"
             else: 
-                pass        
+                pass
 
     def get_current_measurement(self):
         current_meas = (self.query_ascii_values(':MEAS:CURR?'))
@@ -233,7 +215,7 @@ class K2410(GpibDevice):
 
     def update(self):
         self.get_output_state()
-        if (self.output_state) and (self.device_control_enable):       
+        if (self.output_state) and (self.device_control_enable):
             self.get_filter_state()
             self.get_filter_curr_count()
             self.get_filter_curr_type()
@@ -261,18 +243,16 @@ class K2410(GpibDevice):
                     count = setpoint
                 v_set = str(count)
                 self.write((':SOUR:VOLT:LEV %s' %v_set))
-                
                 time.sleep(1)
 
-        if increment > 0: 
-            count = volt_measurement 
+        if increment > 0:
+            count = volt_measurement
             while ((count < setpoint) and self.ramping_flag):
                 count += increment
                 if count > setpoint:
                     count = setpoint
                 v_set = str(count)
                 self.write((':SOUR:VOLT:LEV %s' %v_set))
-                
                 time.sleep(1)
 
         self.ramping_flag = False

--- a/src/odin_gpib/keithley2410.py
+++ b/src/odin_gpib/keithley2410.py
@@ -30,8 +30,11 @@ class K2410(GpibDevice):
         
         print("OUTPUT: ",self.output_state)
 
-        self.device_control_enable = True 
-        self.ramping_flag = False 
+        self.device_control_enable = True
+        self.ramping_flag = False
+        self.identify = False
+        self.write(':DISP:WINDOW1:TEXT:STAT 0')
+        self.write(':DISP:WINDOW2:TEXT:STAT 0')
 
         self.filter_set_enable = ""
         self.filter_set_type = ""
@@ -79,6 +82,7 @@ class K2410(GpibDevice):
             'output_state': (lambda: self.output_state, self.set_output_state),
             'device_control_state': (lambda: self.device_control_enable, self.set_control_enable),
             'ramping_flag': (lambda: self.ramping_flag, self.set_ramping_flag),
+            'identify': (lambda: self.identify, self.set_identify),
             'type': (lambda: self.type, None),
             'ident': (lambda: self.ident, None),
             'address': (lambda: self.bus_address, None),
@@ -86,6 +90,7 @@ class K2410(GpibDevice):
             'voltage': voltage_controls,
             'current': current_controls
             })
+
     def set_time(self, time):
         self.voltage_time = time
     
@@ -116,6 +121,23 @@ class K2410(GpibDevice):
         self.device_control_enable = device_control_enable
         if (self.device_control_enable == False):
             self.write(':SYSTEM:KEY 23')
+
+    def set_identify(self, identify):
+        self.identify = identify
+        #ident = self.ident
+        # If identify toggle turned on, display the identify message on the screen.
+        # To do this, message state needs to be turned on.
+        # Max character length for top display message = 12 characters
+        # Max character length for bottom display message = 32 characters
+        if (self.identify == True):
+            self.write(':DISP:WINDOW1:TEXT:DATA "Identify"')
+            self.write(':DISP:WINDOW1:TEXT:STAT 1')
+            self.write(':DISP:WINDOW2:TEXT:DATA "Bottom Text - Yay"')
+            self.write(':DISP:WINDOW2:TEXT:STAT 1')
+        # Else, disable the message state to remove the message
+        else:
+            self.write(':DISP:WINDOW1:TEXT:STAT 0')
+            self.write(':DISP:WINDOW2:TEXT:STAT 0')
                                                
     def get_voltage_measurement(self):
         voltage_meas = (self.query_ascii_values(':MEAS:VOLT?'))

--- a/src/odin_gpib/keithley2410.py
+++ b/src/odin_gpib/keithley2410.py
@@ -32,8 +32,9 @@ class K2410(GpibDevice):
 
         self.device_control_enable = True
         self.ramping_flag = False
-        self.write(':DISP:WINDOW1:TEXT:STAT 0')
-        self.write(':DISP:WINDOW2:TEXT:STAT 0')
+
+        # Reset the display text, in case identify message was left on
+        self.set_identify(False)
 
         self.filter_set_enable = ""
         self.filter_set_type = ""

--- a/src/odin_gpib/keithley2510.py
+++ b/src/odin_gpib/keithley2510.py
@@ -27,7 +27,6 @@ class K2510(GpibDevice):
         self.device_control_enable = True
         self.output_state = False
         self.temp_over_state = False
-        self.identify = False
         self.write(':DISP:WINDOW1:TEXT:STAT 0')
         self.write(':DISP:WINDOW2:TEXT:STAT 0')
 
@@ -61,7 +60,6 @@ class K2510(GpibDevice):
             'device_control_state': (lambda: self.device_control_enable, self.set_control_enable),
             'temp_over_state': (lambda: self.temp_over_state, self.set_temp_over_state),
             'identify': (lambda: self.identify, self.set_identify),
-            #'identify': (lambda: self.identify, GpibDevice.set_identify(GpibDevice, device=self, identify=self.identify)),
             'type': (lambda: self.type, None),
             'ident': (lambda: self.ident, None),
             'address': (lambda: self.bus_address, None),
@@ -71,23 +69,6 @@ class K2510(GpibDevice):
 
     def set_temp_over_state(self, temp_state):
         self.temp_over_state = temp_state
-
-    def set_identify(self, identify):
-        self.identify = identify
-        #ident = self.ident
-        # If identify toggle turned on, display the identify message on the screen.
-        # To do this, message state needs to be turned on.
-        # Max character length for top display message = 12 characters
-        # Max character length for bottom display message = 32 characters
-        if (self.identify == True):
-            self.write(':DISP:WINDOW1:TEXT:DATA "Identify"')
-            self.write(':DISP:WINDOW1:TEXT:STAT 1')
-            self.write(':DISP:WINDOW2:TEXT:DATA "Bottom Text - Yay"')
-            self.write(':DISP:WINDOW2:TEXT:STAT 1')
-        # Else, disable the message state to remove the message
-        else:
-            self.write(':DISP:WINDOW1:TEXT:STAT 0')
-            self.write(':DISP:WINDOW2:TEXT:STAT 0')
 
     def get_tec_volt_lim(self):
         volt_lim = (self.query_ascii_values(':SOUR:VOLT:PROT?'))

--- a/src/odin_gpib/keithley2510.py
+++ b/src/odin_gpib/keithley2510.py
@@ -27,8 +27,9 @@ class K2510(GpibDevice):
         self.device_control_enable = True
         self.output_state = False
         self.temp_over_state = False
-        self.write(':DISP:WINDOW1:TEXT:STAT 0')
-        self.write(':DISP:WINDOW2:TEXT:STAT 0')
+
+        # Reset the display text, in case identify message was left on
+        self.set_identify(False)
 
         #Make outp? check function in gpibdevice class
         output_init_state = self.device.query(':OUTP?')

--- a/src/odin_gpib/keithley2510.py
+++ b/src/odin_gpib/keithley2510.py
@@ -27,6 +27,9 @@ class K2510(GpibDevice):
         self.device_control_enable = True
         self.output_state = False
         self.temp_over_state = False
+        self.identify = False
+        self.write(':DISP:WINDOW1:TEXT:STAT 0')
+        self.write(':DISP:WINDOW2:TEXT:STAT 0')
 
         #Make outp? check function in gpibdevice class
         output_init_state = self.device.query(':OUTP?')
@@ -57,6 +60,8 @@ class K2510(GpibDevice):
             'output_state': (lambda: self.output_state, self.set_output_state),
             'device_control_state': (lambda: self.device_control_enable, self.set_control_enable),
             'temp_over_state': (lambda: self.temp_over_state, self.set_temp_over_state),
+            'identify': (lambda: self.identify, self.set_identify),
+            #'identify': (lambda: self.identify, GpibDevice.set_identify(GpibDevice, device=self, identify=self.identify)),
             'type': (lambda: self.type, None),
             'ident': (lambda: self.ident, None),
             'address': (lambda: self.bus_address, None),
@@ -65,14 +70,31 @@ class K2510(GpibDevice):
         })
 
     def set_temp_over_state(self, temp_state):
-        self.temp_over_state = temp_state 
+        self.temp_over_state = temp_state
+
+    def set_identify(self, identify):
+        self.identify = identify
+        #ident = self.ident
+        # If identify toggle turned on, display the identify message on the screen.
+        # To do this, message state needs to be turned on.
+        # Max character length for top display message = 12 characters
+        # Max character length for bottom display message = 32 characters
+        if (self.identify == True):
+            self.write(':DISP:WINDOW1:TEXT:DATA "Identify"')
+            self.write(':DISP:WINDOW1:TEXT:STAT 1')
+            self.write(':DISP:WINDOW2:TEXT:DATA "Bottom Text - Yay"')
+            self.write(':DISP:WINDOW2:TEXT:STAT 1')
+        # Else, disable the message state to remove the message
+        else:
+            self.write(':DISP:WINDOW1:TEXT:STAT 0')
+            self.write(':DISP:WINDOW2:TEXT:STAT 0')
 
     def get_tec_volt_lim(self):
         volt_lim = (self.query_ascii_values(':SOUR:VOLT:PROT?'))
         if (volt_lim == None):
             pass
         else:
-            self.tec_volt_lim = ("{:.6f}".format(float(volt_lim[0])))    
+            self.tec_volt_lim = ("{:.6f}".format(float(volt_lim[0])))
 
     def get_tec_curr_lim(self):
         curr_lim = (self.query_ascii_values(':SENS:CURR:PROT?'))
@@ -80,7 +102,6 @@ class K2510(GpibDevice):
             pass
         else:
             self.tec_curr_lim = ("{:.6f}".format(float(curr_lim[0])))
-        
 
     def get_tec_power(self):
         tec_power = (self.query_ascii_values(':MEAS:POW?'))
@@ -94,14 +115,14 @@ class K2510(GpibDevice):
         if (tec_current == None):
             pass
         else:
-            self.tec_current = ("{:.6f}".format(float(tec_current[0])))        
+            self.tec_current = ("{:.6f}".format(float(tec_current[0])))
 
     def get_tec_voltage(self):
         tec_voltage = (self.query_ascii_values(':MEAS:VOLT?'))
         if (tec_voltage == None):
             pass
         else:
-            self.tec_voltage = ("{:.6f}".format(float(tec_voltage[0])))        
+            self.tec_voltage = ("{:.6f}".format(float(tec_voltage[0])))
 
     def get_tec_temp_meas(self):
         tec_temp_meas = (self.query_ascii_values(':MEAS:TEMP?'))
@@ -115,14 +136,14 @@ class K2510(GpibDevice):
                 self.output_state = False
                 self.write(':OUTP OFF')
             else:
-                logging.debug("Under temp")    
-    
+                logging.debug("Under temp")
+
     def get_tec_setpoint(self):
         tec_setpoint = (self.query_ascii_values(':SOUR:TEMP?'))
         if (tec_setpoint == None):
             pass
         else:
-            self.tec_setpoint = ("{:.6f}".format(float(tec_setpoint[0])))        
+            self.tec_setpoint = ("{:.6f}".format(float(tec_setpoint[0])))
 
     def get_output_state(self):
         output_state = self.query(':OUTP?')

--- a/test/static/css/odin-server.css
+++ b/test/static/css/odin-server.css
@@ -107,6 +107,7 @@ position: relative;
 .switch-label
 {
 padding-bottom: 15px;
+width: 110px;
 }
 
 .slider

--- a/test/static/js/odin_server.js
+++ b/test/static/js/odin_server.js
@@ -68,7 +68,7 @@ function create_K2410_interfaces(){
 
                 <div>
                     <label class = "switch-label" for = "enable-toggle-${id}">
-                    <p>Enable control&nbsp&nbsp</p>
+                    <p>Enable control</p>
                     </label>
                     <label class = "switch">
                     <input type="checkbox" onclick="set_enable_k2410('${id}')" id="enable-toggle-${id}">
@@ -78,7 +78,7 @@ function create_K2410_interfaces(){
 
                 <div>
                     <label class = "switch-label" for = "output-toggle-${id}">
-                    <p>Enable output&nbsp&nbsp&nbsp</p>
+                    <p>Enable output</p>
                     </label>
                     <label class = "switch">
                     <input class type="checkbox" onclick="set_output_k2410('${id}')" id="output-toggle-${id}">

--- a/test/static/js/odin_server.js
+++ b/test/static/js/odin_server.js
@@ -92,6 +92,15 @@ function create_K2410_interfaces(){
                     <span class="slider"> </span>
                     </label>
                 </div>
+                <div>
+                    <label class = "switch-label" for = "identify-toggle-${id}">
+                    <p>Identify</p>
+                    </label>
+                    <label class = "switch">
+                    <input class type="checkbox" onclick="identify_k2410('${id}')" id="identify-toggle-${id}">
+                    <span class="slider"> </span>
+                    </label>
+                </div>
             </div>
         </div>
         <div class="row">
@@ -262,9 +271,18 @@ function create_K2510_interfaces(){
                     <span class="slider"> </span>
                     </label>
                 </div>
-                    <div>
-                        <button onclick="set_over_temp('${id}')" id="reset-temp-${id}">Reset over_temp state</button>
-                    </div>
+                <div>
+                    <label class = "switch-label" for = "identify-toggle-${id}">
+                    <p>Identify</p>
+                    </label>
+                    <label class = "switch">
+                    <input class type="checkbox" onclick="identify_k2510('${id}')" id="identify-toggle-${id}">
+                    <span class="slider"> </span>
+                    </label>
+                </div>
+                <div>
+                    <button onclick="set_over_temp('${id}')" id="reset-temp-${id}">Reset over_temp state</button>
+                </div>
             </div>
         </div>
         <ul class="row">
@@ -368,6 +386,7 @@ function update_k2410_elements(id) {
     return function(response) {
         (document.getElementById("enable-toggle-"+id)).checked = (response[id].device_control_state);
         (document.getElementById("output-toggle-"+id)).checked = (response[id].output_state);
+        (document.getElementById("identify-toggle-" + id)).checked = (response[id].identify);
         // Section of code runs for each K2410 device when the page is loaded
         if (up_i<(K2410_devices.length)){
             //Sets the inital state of the dropdowns so that they are in sync with the adapter state
@@ -480,6 +499,11 @@ function set_ramping_k2410(id) {
     }
 }
 
+function identify_k2410(id) {
+    var toggle = $('#identify-toggle-' + id).prop('checked');
+    ajax_put(id, 'identify', toggle)
+}
+
 function cancel_ramp(id){
     var value = false
     ajax_put(id,'ramping_flag',value)
@@ -497,6 +521,7 @@ function update_k2510_elements(id) {
 
         (document.getElementById("enable-toggle-"+id)).checked = (response[id].device_control_state);
         (document.getElementById("output-toggle-"+id)).checked = (response[id].output_state);
+        (document.getElementById("identify-toggle-" + id)).checked = (response[id].identify);
 
         if (response[id].output_state){
             $("#tec-out-state-"+id).html("Enabled");
@@ -717,6 +742,11 @@ function set_output_k2510(id){
 function set_over_temp(id){
     var value = false
     ajax_put(id,'temp_over_state',value);
+}
+
+function identify_k2510(id) {
+    var toggle = $('#identify-toggle-' + id).prop('checked');
+    ajax_put(id, 'identify', toggle)
 }
 
 function ajax_put(path,key,value){

--- a/test/static/js/odin_server.js
+++ b/test/static/js/odin_server.js
@@ -65,6 +65,7 @@ function create_K2410_interfaces(){
         <div class = "device-label">
             <div class = "container-fluid">
                 <div> Keithley 2410 power supply: ${id}</div>
+
                 <div>
                     <label class = "switch-label" for = "enable-toggle-${id}">
                     <p>Enable control&nbsp&nbsp</p>
@@ -74,6 +75,7 @@ function create_K2410_interfaces(){
                     <span class="slider"> </span>
                     </label>
                 </div>
+
                 <div>
                     <label class = "switch-label" for = "output-toggle-${id}">
                     <p>Enable output&nbsp&nbsp&nbsp</p>
@@ -83,6 +85,7 @@ function create_K2410_interfaces(){
                     <span class="slider"> </span>
                     </label>
                 </div>
+
                 <div>
                     <label class = "switch-label" for = "ramping-toggle-${id}">
                     <p>Enable ramping</p>
@@ -92,6 +95,7 @@ function create_K2410_interfaces(){
                     <span class="slider"> </span>
                     </label>
                 </div>
+
                 <div>
                     <label class = "switch-label" for = "identify-toggle-${id}">
                     <p>Identify</p>
@@ -252,9 +256,10 @@ function create_K2510_interfaces(){
         <div class = "device-label">
             <div class = "container-fluid">
                 <div> Keithley 2510 Peltier Controller: ${id}</div>
+
                 <div>
                     <label class = "switch-label" for = "enable-toggle-${id}">
-                    Enable control&nbsp&nbsp
+                    <p>Enable control</p>
                     </label>
                     <label class = "switch">
                         <input type="checkbox" onclick="set_enable_k2510('${id}')" id="enable-toggle-${id}">
@@ -271,6 +276,7 @@ function create_K2510_interfaces(){
                     <span class="slider"> </span>
                     </label>
                 </div>
+
                 <div>
                     <label class = "switch-label" for = "identify-toggle-${id}">
                     <p>Identify</p>
@@ -280,6 +286,7 @@ function create_K2510_interfaces(){
                     <span class="slider"> </span>
                     </label>
                 </div>
+
                 <div>
                     <button onclick="set_over_temp('${id}')" id="reset-temp-${id}">Reset over_temp state</button>
                 </div>


### PR DESCRIPTION
- used through the api with a toggle
- shows an identify message on device screen
- add the device identifier code onto the device display when it's identified
- some code improvements (e.g. whitespace removal)
- add width tag in css for toggle-label which aligns all the toggles together

resolves #2